### PR TITLE
Fix errorHandler middleware response

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -13,12 +13,10 @@ import { logger } from "../utils/logger";
 export const errorHandler = async (
   c: Context,
   next: Next,
-): Promise<Response> => {
+): Promise<Response | void> => {
   try {
     // 次のミドルウェアまたはハンドラを実行
     await next();
-    // デフォルトのレスポンスを返す
-    return new Response("OK", { status: 200 });
   } catch (error) {
     // エラーをログに記録
     logger.error("リクエスト処理中にエラーが発生しました", error);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Prevent `errorHandler` from overriding successful downstream responses by removing its default 'OK' return.