### PR TITLE
Fix error handler JSON response

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -39,6 +39,7 @@ export const errorHandler = async (
         status: "error",
         message: error.message,
       };
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       return c.json(response, error.statusCode as 400 | 401 | 403 | 404 | 500);
     }
 

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -39,8 +39,7 @@ export const errorHandler = async (
         status: "error",
         message: error.message,
       };
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      return c.json(response, error.statusCode as 400 | 401 | 403 | 404 | 500);
+      return c.json(response, error.statusCode);
     }
 
     // 予期しないエラー

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -39,7 +39,7 @@ export const errorHandler = async (
         status: "error",
         message: error.message,
       };
-      return c.json(response, error.statusCode);
+      return c.json(response, error.statusCode as 400 | 401 | 403 | 404 | 500);
     }
 
     // 予期しないエラー

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -39,10 +39,7 @@ export const errorHandler = async (
         status: "error",
         message: error.message,
       };
-      return new Response(JSON.stringify(response), {
-        status: error.statusCode,
-        headers: { "Content-Type": "application/json" },
-      });
+      return c.json(response, error.statusCode);
     }
 
     // 予期しないエラー
@@ -50,9 +47,6 @@ export const errorHandler = async (
       status: "error",
       message: "内部サーバーエラーが発生しました",
     };
-    return new Response(JSON.stringify(response), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return c.json(response, 500);
   }
 };

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,11 +1,20 @@
 /**
+ * HTTPステータスコードの型定義
+ */
+export type HttpStatusCode = 400 | 401 | 403 | 404 | 500 | 502 | 503;
+
+/**
  * アプリケーション固有のエラークラス
  */
 export class AppError extends Error {
-  statusCode: number;
+  statusCode: HttpStatusCode;
   isOperational: boolean;
 
-  constructor(message: string, statusCode = 500, isOperational = true) {
+  constructor(
+    message: string,
+    statusCode: HttpStatusCode = 500,
+    isOperational = true,
+  ) {
     super(message);
     this.statusCode = statusCode;
     this.isOperational = isOperational;


### PR DESCRIPTION
Refactor error handling to use Hono's `c.json()` for consistent response patterns and improved middleware compatibility.