### PR TITLE
Change wording for schedule inquiries

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,9 +3,9 @@ export const COMMAND_PREFIX = "/";
 
 // 準備方法の日本語表示マッピング
 export const PREPARATION_TYPE_TEXT = {
-  COOK_BY_SELF: "自炊",
-  INDIVIDUAL: "各自自由",
-  BUY_TOGETHER: "買って一緒に食べる",
+  COOK_BY_SELF: "家で食べる（担当：自分）",
+  INDIVIDUAL: "各自外で食べる",
+  BUY_TOGETHER: "家で食べる（担当：誰か）",
 } as const;
 
 // 食事タイプの日本語表示マッピング
@@ -22,7 +22,7 @@ export const MESSAGES = {
     INVALID_MEAL_TYPE:
       "無効な食事タイプです。lunch または dinner を使用してください。",
     INVALID_PREPARATION_TYPE:
-      "無効な準備方法です。cook, individual, または buy を使用してください。",
+      "無効な準備方法です。cook（家で食べる・担当：自分）, individual（各自外で食べる）, または buy（家で食べる・担当：誰か）を使用してください。",
     MISSING_PARAMETERS:
       "必要なパラメータが不足しています。もう一度お試しください。",
     REGISTRATION_FAILED:
@@ -39,7 +39,7 @@ export const MESSAGES = {
   日付: today, tomorrow, YYYY-MM-DD
   食事タイプ: lunch, dinner
   参加: yes, no
-  準備方法: cook, individual, buy
+  準備方法: cook（家で食べる・担当：自分）, individual（各自外で食べる）, buy（家で食べる・担当：誰か）
 /check [日付] - 食事予定を確認
   例: /check tomorrow
   日付: today, tomorrow, YYYY-MM-DD (省略時は today)
@@ -54,7 +54,7 @@ export const MESSAGES = {
 ヘルプ - このヘルプを表示`,
     CALENDAR_EXPLANATION: "カレンダーから日付を選択して、予定を確認できます。",
     REGISTER_USAGE:
-      "使用方法: /register <日付(today/tomorrow/YYYY-MM-DD)> <食事タイプ(lunch/dinner)> <参加(yes/no)> [準備方法(cook/individual/buy)]",
+      "使用方法: /register <日付(today/tomorrow/YYYY-MM-DD)> <食事タイプ(lunch/dinner)> <参加(yes/no)> [準備方法(cook:家で食べる・担当：自分/individual:各自外で食べる/buy:家で食べる・担当：誰か)]",
   },
   SUCCESS: {
     REGISTRATION_COMPLETE: "予定を登録しました。",

--- a/src/services/line.ts
+++ b/src/services/line.ts
@@ -189,11 +189,11 @@ export const createMealPlanFlexMessage = (
   const getPreparationTypeText = (type: string, cooker?: string) => {
     switch (type) {
       case "COOK_BY_SELF":
-        return cooker ? `${cooker}が作る` : "自炊";
+        return cooker ? `家で食べる（担当：${cooker}）` : "家で食べる（担当：自分）";
       case "INDIVIDUAL":
-        return "各自自由に";
+        return "各自外で食べる";
       case "BUY_TOGETHER":
-        return "買って一緒に食べる";
+        return "家で食べる（担当：誰か）";
       default:
         return "未定";
     }
@@ -501,21 +501,21 @@ export const sendRegistrationOptions = async (
       actions: [
         {
           type: "postback",
-          label: "参加する",
+          label: "家で食べる（担当：自分）",
           data: `confirm_registration?date=${dateStr}&mealType=${mealType}&attend=true&prepType=COOK_BY_SELF`,
-          displayText: "参加する（自炊）",
+          displayText: "家で食べる（担当：自分）",
         },
         {
           type: "postback",
-          label: "参加する（各自）",
-          data: `confirm_registration?date=${dateStr}&mealType=${mealType}&attend=true&prepType=INDIVIDUAL`,
-          displayText: "参加する（各自自由に）",
-        },
-        {
-          type: "postback",
-          label: "参加する（買う）",
+          label: "家で食べる（担当：誰か）",
           data: `confirm_registration?date=${dateStr}&mealType=${mealType}&attend=true&prepType=BUY_TOGETHER`,
-          displayText: "参加する（買って一緒に食べる）",
+          displayText: "家で食べる（担当：誰か）",
+        },
+        {
+          type: "postback",
+          label: "各自外で食べる",
+          data: `confirm_registration?date=${dateStr}&mealType=${mealType}&attend=true&prepType=INDIVIDUAL`,
+          displayText: "各自外で食べる",
         },
         {
           type: "postback",


### PR DESCRIPTION
Update meal preparation option display text to match user's requested wording.

The user requested specific Japanese phrases for meal preparation options. This PR updates the UI text and related messages without altering the underlying `PreparationType` enum or database structure, ensuring backward compatibility.