### PR TITLE
Fix date validation in parseDate function

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -71,6 +71,17 @@ export const parseDate = (dateStr: string): Date | null => {
       return null;
     }
 
+    // 作成されたDateオブジェクトの年月日が元の入力と一致するかチェック
+    // JavaScript の Date コンストラクタは無効な日付（例：2月30日）を自動的に調整するため
+    // 調整後の日付が元の入力と一致しない場合は無効とみなす
+    if (
+      date.getFullYear() !== year ||
+      date.getMonth() !== month - 1 ||
+      date.getDate() !== day
+    ) {
+      return null;
+    }
+
     return date;
   } catch (_) {
     return null;


### PR DESCRIPTION
Add strict date validation to `parseDate` to prevent silent rollover of invalid dates.

The `Date` constructor in JavaScript silently adjusts invalid dates (e.g., '2023-02-30' becomes March 2, 2023). This PR adds a check to ensure the year, month, and day of the created `Date` object exactly match the input components, returning `null` for truly invalid dates.