### PR TITLE
Create a script for multiple tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "find-user": "tsx scripts/find_user.ts",
     "setup-richmenu": "tsx scripts/setupRichMenu.ts",
     "setup-richmenu:mock": "tsx scripts/setupRichMenuWithMock.ts",
-    "setup-richmenu:theme": "tsx scripts/setupRichMenuWithTheme.ts"
+    "setup-richmenu:theme": "tsx scripts/setupRichMenuWithTheme.ts",
+    "ci": "npm run format && npm run check && npm run lint && npm run test && npm run build",
+    "verify": "npm run format && npm run check && npm run lint && npm run test && npm run build"
   },
   "keywords": [
     "line",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "setup-richmenu:mock": "tsx scripts/setupRichMenuWithMock.ts",
     "setup-richmenu:theme": "tsx scripts/setupRichMenuWithTheme.ts",
     "ci": "npm run format && npm run check && npm run lint && npm run test && npm run type-check",
-    "verify": "npm run format && npm run check && npm run lint && npm run test && npm run type-check",
     "ci:build": "npm run format && npm run check && npm run lint && npm run test && npm run build"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
+    "type-check": "tsc --noEmit",
     "start": "node dist/index.js",
     "check": "biome check src --write",
     "lint": "eslint --ext .ts src --fix",
@@ -27,8 +28,9 @@
     "setup-richmenu": "tsx scripts/setupRichMenu.ts",
     "setup-richmenu:mock": "tsx scripts/setupRichMenuWithMock.ts",
     "setup-richmenu:theme": "tsx scripts/setupRichMenuWithTheme.ts",
-    "ci": "npm run format && npm run check && npm run lint && npm run test && npm run build",
-    "verify": "npm run format && npm run check && npm run lint && npm run test && npm run build"
+    "ci": "npm run format && npm run check && npm run lint && npm run test && npm run type-check",
+    "verify": "npm run format && npm run check && npm run lint && npm run test && npm run type-check",
+    "ci:build": "npm run format && npm run check && npm run lint && npm run test && npm run build"
   },
   "keywords": [
     "line",


### PR DESCRIPTION
Add `ci`, `verify`, `ci:build`, and `type-check` scripts to `package.json` to streamline quality checks and enable quick type-checking without a full build.