### PR TITLE
Fix future schedule menu regression

### DIFF
--- a/src/features/line/handlers/message.ts
+++ b/src/features/line/handlers/message.ts
@@ -10,7 +10,10 @@ import {
   handleHelpCommand,
   handleRegisterCommand,
 } from "../../meal/commands";
-import { sendCalendarMessage, send7DayCalendarMessage } from "../../meal/services/calendar";
+import {
+  send7DayCalendarMessage,
+  sendCalendarMessage,
+} from "../../meal/services/calendar";
 import { getMealPlans } from "../../meal/services/meal";
 import { getUserByLineId } from "../../meal/services/user";
 import {
@@ -297,13 +300,13 @@ const handleFutureMenu = async (
   const mealPlans = await getMealPlans(today, nextWeek);
 
   let explanationMessage = "📅 今後7日間のカレンダーです\n\n";
-  
+
   if (mealPlans.length > 0) {
     explanationMessage += `📋 登録済みの予定:\n${formatMealPlans(mealPlans)}\n\n`;
   } else {
     explanationMessage += "📋 登録済みの予定はまだありません\n\n";
   }
-  
+
   explanationMessage += "💡 日付をタップすると詳細確認・編集ができます";
 
   // プッシュメッセージとして詳細説明を送信

--- a/src/features/line/handlers/message.ts
+++ b/src/features/line/handlers/message.ts
@@ -10,13 +10,14 @@ import {
   handleHelpCommand,
   handleRegisterCommand,
 } from "../../meal/commands";
-import { sendCalendarMessage } from "../../meal/services/calendar";
+import { sendCalendarMessage, send7DayCalendarMessage } from "../../meal/services/calendar";
 import { getMealPlans } from "../../meal/services/meal";
 import { getUserByLineId } from "../../meal/services/user";
 import {
   replyTemplateMessage,
   replyTextMessage,
   sendTemplateMessage,
+  sendTextMessage,
 } from "../client";
 import {
   createChangeMenuTemplate,
@@ -280,10 +281,13 @@ const handleThisWeekMenu = async (
  * @param replyToken 応答トークン
  */
 const handleFutureMenu = async (
-  _user: User,
+  user: User,
   replyToken: string,
 ): Promise<void> => {
-  // 今後の予定を表示（例: 1週間分）
+  // 7日間カレンダーを表示
+  await send7DayCalendarMessage(user.lineId, replyToken);
+
+  // 今後の予定の詳細を追加メッセージとして送信
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
@@ -292,17 +296,19 @@ const handleFutureMenu = async (
 
   const mealPlans = await getMealPlans(today, nextWeek);
 
+  let explanationMessage = "📅 今後7日間のカレンダーです\n\n";
+  
   if (mealPlans.length > 0) {
-    await replyTextMessage(
-      replyToken,
-      `今後1週間の予定:\n${formatMealPlans(mealPlans)}`,
-    );
+    explanationMessage += `📋 登録済みの予定:\n${formatMealPlans(mealPlans)}\n\n`;
   } else {
-    await replyTextMessage(
-      replyToken,
-      "今後1週間の予定はまだ登録されていません。",
-    );
+    explanationMessage += "📋 登録済みの予定はまだありません\n\n";
   }
+  
+  explanationMessage += "💡 日付をタップすると詳細確認・編集ができます";
+
+  // プッシュメッセージとして詳細説明を送信
+  // 注: replyToken は一度しか使えないため、2つ目のメッセージはプッシュメッセージとして送信
+  await sendTextMessage(user.lineId, explanationMessage);
 };
 
 /**

--- a/src/features/line/handlers/message.ts
+++ b/src/features/line/handlers/message.ts
@@ -12,7 +12,6 @@ import {
 } from "../../meal/commands";
 import {
   send7DayCalendarMessage,
-  sendCalendarMessage,
 } from "../../meal/services/calendar";
 import { getMealPlans } from "../../meal/services/meal";
 import { getUserByLineId } from "../../meal/services/user";

--- a/src/features/meal/services/calendar.ts
+++ b/src/features/meal/services/calendar.ts
@@ -159,6 +159,113 @@ export const createCalendarFlexMessage = (
 };
 
 /**
+ * 7日間カレンダーFlexメッセージを作成
+ * @param startDate 開始日（デフォルトは今日）
+ * @returns Flexメッセージのコンテンツ
+ */
+export const create7DayCalendarFlexMessage = (
+  startDate: Date = new Date(),
+): FlexBubble => {
+  // 開始日を今日の0時に設定
+  const start = new Date(startDate);
+  start.setHours(0, 0, 0, 0);
+
+  // 曜日の配列
+  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+
+  // 7日分の日付情報を作成
+  const days: FlexComponent[] = [];
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  for (let i = 0; i < 7; i++) {
+    const currentDate = new Date(start);
+    currentDate.setDate(currentDate.getDate() + i);
+    
+    const isToday = currentDate.getTime() === today.getTime();
+    const dayOfWeek = currentDate.getDay();
+    const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+
+    days.push({
+      type: "box" as const,
+      layout: "vertical" as const,
+      contents: [
+        {
+          type: "text" as const,
+          text: weekdays[dayOfWeek],
+          size: "xs",
+          align: "center",
+          color: isWeekend 
+            ? dayOfWeek === 0 ? "#FF0000" : "#0000FF" 
+            : "#666666",
+        },
+        {
+          type: "text" as const,
+          text: String(currentDate.getDate()),
+          size: "md",
+          align: "center",
+          weight: isToday ? "bold" : "regular",
+          color: isToday
+            ? "#FFFFFF"
+            : isWeekend
+              ? dayOfWeek === 0 ? "#FF0000" : "#0000FF"
+              : "#333333",
+        },
+      ],
+      backgroundColor: isToday ? "#1DB446" : "transparent",
+      cornerRadius: "md",
+      paddingAll: "sm",
+      action: {
+        type: "postback" as const,
+        data: `action=select_date&date=${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, "0")}-${String(currentDate.getDate()).padStart(2, "0")}`,
+        displayText: `${currentDate.getFullYear()}年${currentDate.getMonth() + 1}月${currentDate.getDate()}日を選択しました`,
+        label: `${currentDate.getMonth() + 1}/${currentDate.getDate()}`,
+      },
+    });
+  }
+
+  // Flexメッセージを作成
+  return {
+    type: "bubble",
+    header: {
+      type: "box",
+      layout: "vertical",
+      contents: [
+        {
+          type: "text",
+          text: "今後7日間の予定",
+          weight: "bold",
+          color: "#1DB446",
+          size: "lg",
+          align: "center",
+        },
+        {
+          type: "text",
+          text: "日付をタップして詳細を確認",
+          size: "xs",
+          align: "center",
+          color: "#666666",
+          margin: "sm",
+        },
+      ],
+      paddingAll: "md",
+    },
+    body: {
+      type: "box",
+      layout: "horizontal",
+      contents: days,
+      spacing: "xs",
+      paddingAll: "md",
+    },
+    styles: {
+      footer: {
+        separator: true,
+      },
+    },
+  };
+};
+
+/**
  * カレンダーメッセージを送信
  * @param to 送信先ユーザーID
  * @param replyToken 応答トークン（指定された場合は応答メッセージとして送信）
@@ -187,5 +294,35 @@ export const sendCalendarMessage = async (
   } catch (error) {
     logger.error(`カレンダーメッセージ送信エラー: ${to}`, error);
     throw new AppError("カレンダーメッセージの送信に失敗しました", 500);
+  }
+};
+
+/**
+ * 7日間カレンダーメッセージを送信
+ * @param to 送信先ユーザーID
+ * @param replyToken 応答トークン（指定された場合は応答メッセージとして送信）
+ * @param startDate 開始日（デフォルトは今日）
+ * @returns 送信結果
+ */
+export const send7DayCalendarMessage = async (
+  to: string,
+  replyToken?: string,
+  startDate?: Date,
+): Promise<MessageAPIResponseBase> => {
+  try {
+    const flexMessage = create7DayCalendarFlexMessage(startDate);
+    const date = startDate || new Date();
+    const altText = `今後7日間のカレンダー (${date.getMonth() + 1}/${date.getDate()}〜)`;
+
+    // replyTokenが指定されていれば応答メッセージとして送信
+    if (replyToken) {
+      return await replyFlexMessage(replyToken, flexMessage, altText);
+    }
+
+    // そうでなければプッシュメッセージとして送信
+    return await sendFlexMessage(to, flexMessage, altText);
+  } catch (error) {
+    logger.error(`7日間カレンダーメッセージ送信エラー: ${to}`, error);
+    throw new AppError("7日間カレンダーメッセージの送信に失敗しました", 500);
   }
 };

--- a/src/features/meal/services/calendar.ts
+++ b/src/features/meal/services/calendar.ts
@@ -181,7 +181,7 @@ export const create7DayCalendarFlexMessage = (
   for (let i = 0; i < 7; i++) {
     const currentDate = new Date(start);
     currentDate.setDate(currentDate.getDate() + i);
-    
+
     const isToday = currentDate.getTime() === today.getTime();
     const dayOfWeek = currentDate.getDay();
     const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
@@ -195,8 +195,10 @@ export const create7DayCalendarFlexMessage = (
           text: weekdays[dayOfWeek],
           size: "xs",
           align: "center",
-          color: isWeekend 
-            ? dayOfWeek === 0 ? "#FF0000" : "#0000FF" 
+          color: isWeekend
+            ? dayOfWeek === 0
+              ? "#FF0000"
+              : "#0000FF"
             : "#666666",
         },
         {
@@ -208,7 +210,9 @@ export const create7DayCalendarFlexMessage = (
           color: isToday
             ? "#FFFFFF"
             : isWeekend
-              ? dayOfWeek === 0 ? "#FF0000" : "#0000FF"
+              ? dayOfWeek === 0
+                ? "#FF0000"
+                : "#0000FF"
               : "#333333",
         },
       ],

--- a/tests/unit/handlers/message.test.ts
+++ b/tests/unit/handlers/message.test.ts
@@ -60,7 +60,8 @@ describe("メッセージハンドラー", () => {
 
   it("「今後の予定」メッセージを処理できること", async () => {
     // モックのセットアップ
-    const replyTextMessageMock = vi.spyOn(lineService, "replyTextMessage");
+    const send7DayCalendarMessageMock = vi.spyOn(calendarService, "send7DayCalendarMessage");
+    const sendTextMessageMock = vi.spyOn(lineService, "sendTextMessage");
     
     // テスト対象の実行
     const mockUser = { lineId: "test-user-id", name: "Test User", id: 1 };
@@ -68,6 +69,7 @@ describe("メッセージハンドラー", () => {
     await handleTextMessage({ type: "text", text: "今後の予定" }, mockUser, mockReplyToken);
     
     // 検証
-    expect(replyTextMessageMock).toHaveBeenCalledWith(mockReplyToken, expect.any(String));
+    expect(send7DayCalendarMessageMock).toHaveBeenCalledWith(mockUser.lineId, mockReplyToken);
+    expect(sendTextMessageMock).toHaveBeenCalledWith(mockUser.lineId, expect.any(String));
   });
 }); 

--- a/tests/unit/handlers/message.test.ts
+++ b/tests/unit/handlers/message.test.ts
@@ -61,7 +61,7 @@ describe("メッセージハンドラー", () => {
   it("「今後の予定」メッセージを処理できること", async () => {
     // モックのセットアップ
     const send7DayCalendarMessageMock = vi.spyOn(calendarService, "send7DayCalendarMessage");
-    const sendTextMessageMock = vi.spyOn(lineService, "sendTextMessage");
+    const sendTextMessageMock = vi.spyOn(client, "sendTextMessage");
     
     // テスト対象の実行
     const mockUser = { lineId: "test-user-id", name: "Test User", id: 1 };


### PR DESCRIPTION
Restore and enhance '今後の予定' menu to display a 7-day calendar view and an explanation message.

The '今後の予定' menu option had regressed to only show a text list of meal plans. This PR reintroduces a calendar view, specifically a new 7-day horizontal calendar, along with a detailed explanation message.