### PR TITLE
feat: 夕飯編集時に準備者を奪うボタンを追加

### DIFF
--- a/src/domain/entities/MealPlan.ts
+++ b/src/domain/entities/MealPlan.ts
@@ -161,7 +161,7 @@ export class MealPlan {
     this._preparationRole = newPreparer;
 
     // 新しい準備者の参加状況を確実に「参加する」に設定
-    this._setParticipationStatus(newPreparer, ParticipationStatus.WILL_PARTICIPATE);
+    this._setPreparerParticipationStatus(newPreparer, ParticipationStatus.WILL_PARTICIPATE);
 
     this.updateCurrentState();
     this._updatedAt = new Date();
@@ -170,10 +170,10 @@ export class MealPlan {
 
   /**
    * 指定した準備者の参加ステータスを設定する
-   * @param preparer 準備者
+   * @param preparer 準備者（ALICEまたはBOBのみ対応）
    * @param status 参加ステータス
    */
-  private _setParticipationStatus(preparer: PreparationRole, status: ParticipationStatus): void {
+  private _setPreparerParticipationStatus(preparer: PreparationRole, status: ParticipationStatus): void {
     if (preparer === PreparationRole.ALICE) {
       this._aliceParticipation = status;
     } else if (preparer === PreparationRole.BOB) {

--- a/src/domain/entities/MealPlan.ts
+++ b/src/domain/entities/MealPlan.ts
@@ -161,15 +161,24 @@ export class MealPlan {
     this._preparationRole = newPreparer;
 
     // 新しい準備者の参加状況を確実に「参加する」に設定
-    if (newPreparer === PreparationRole.ALICE) {
-      this._aliceParticipation = ParticipationStatus.WILL_PARTICIPATE;
-    } else {
-      this._bobParticipation = ParticipationStatus.WILL_PARTICIPATE;
-    }
+    this._setParticipationStatus(newPreparer, ParticipationStatus.WILL_PARTICIPATE);
 
     this.updateCurrentState();
     this._updatedAt = new Date();
     return Result.success();
+  }
+
+  /**
+   * 指定した準備者の参加ステータスを設定する
+   * @param preparer 準備者
+   * @param status 参加ステータス
+   */
+  private _setParticipationStatus(preparer: PreparationRole, status: ParticipationStatus): void {
+    if (preparer === PreparationRole.ALICE) {
+      this._aliceParticipation = status;
+    } else if (preparer === PreparationRole.BOB) {
+      this._bobParticipation = status;
+    }
   }
 
   private updateCurrentState(): void {

--- a/src/domain/entities/MealPlan.ts
+++ b/src/domain/entities/MealPlan.ts
@@ -136,6 +136,31 @@ export class MealPlan {
     return Result.success();
   }
 
+  changePreparationRole(newPreparer: PreparationRole): Result<void> {
+    if (this.mealType === MealType.LUNCH) {
+      return Result.failure("Lunch preparation role cannot be changed.");
+    }
+
+    if (newPreparer === PreparationRole.NONE) {
+      return Result.failure(
+        "Cannot set preparation role to NONE. Use preparerQuits() instead.",
+      );
+    }
+
+    this._preparationRole = newPreparer;
+
+    // 新しい準備者の参加状況を確実に「参加する」に設定
+    if (newPreparer === PreparationRole.ALICE) {
+      this._aliceParticipation = ParticipationStatus.WILL_PARTICIPATE;
+    } else {
+      this._bobParticipation = ParticipationStatus.WILL_PARTICIPATE;
+    }
+
+    this.updateCurrentState();
+    this._updatedAt = new Date();
+    return Result.success();
+  }
+
   private updateCurrentState(): void {
     if (this.mealType === MealType.LUNCH) {
       if (this._preparationRole === PreparationRole.BOB) {

--- a/src/domain/entities/MealPlan.ts
+++ b/src/domain/entities/MealPlan.ts
@@ -136,6 +136,17 @@ export class MealPlan {
     return Result.success();
   }
 
+  /**
+   * Changes the meal preparation role to the specified new preparer.
+   *
+   * This method enforces business rules:
+   * - The preparation role for lunch cannot be changed; attempting to do so will fail.
+   * - The preparation role cannot be set to `NONE` using this method; use `preparerQuits()` instead.
+   * - When the preparation role is changed, the new preparer's participation status is automatically set to `WILL_PARTICIPATE`.
+   *
+   * @param {PreparationRole} newPreparer - The new preparer role to assign. Must be either `ALICE` or `BOB`.
+   * @returns {Result<void>} A Result indicating success, or failure with a message if the change is not allowed.
+   */
   changePreparationRole(newPreparer: PreparationRole): Result<void> {
     if (this.mealType === MealType.LUNCH) {
       return Result.failure("Lunch preparation role cannot be changed.");

--- a/src/features/line/handlers/postback.ts
+++ b/src/features/line/handlers/postback.ts
@@ -65,7 +65,8 @@ export const handlePostbackEvent = async (
       case "participate":
       case "not_participate":
       case "undecided":
-      case "quit_preparation": {
+      case "quit_preparation":
+      case "take_preparation": {
         const mealType = params.get("mealType");
         console.log(
           `[PostbackHandler] 食事アクション処理: ${action}, mealType: ${mealType}`,

--- a/src/features/line/handlers/postbacks/dinner.ts
+++ b/src/features/line/handlers/postbacks/dinner.ts
@@ -11,7 +11,15 @@ import { replyFlexMessage, replyTextMessage } from "../../client";
 import { createDinnerEditFlexMessage } from "../../messages/dinner-edit";
 
 /**
- * 編集画面表示処理
+ * Handles displaying the edit screen for a dinner meal plan.
+ *
+ * @param event - The LINE postback event triggering the edit action.
+ * @param mealService - Service for retrieving or creating meal plans.
+ * @param date - The date of the meal to edit.
+ * @param dateStr - The string representation of the meal date (for display).
+ * @param person - The person ("Alice" or "Bob") for whom the edit UI is being shown.
+ *   This determines which user's context is used in the UI flow (e.g., whose role or preferences are displayed).
+ * @returns A promise that resolves when the edit message has been sent.
  */
 const handleEditMeal = async (
   event: PostbackEvent,

--- a/src/features/line/handlers/postbacks/dinner.ts
+++ b/src/features/line/handlers/postbacks/dinner.ts
@@ -124,15 +124,24 @@ export const handleDinnerPostback = async (
       console.log("[DinnerPostback] 準備担当を奪う");
       const newPreparer =
         person === "Alice" ? PreparationRole.ALICE : PreparationRole.BOB;
-      await mealService.changePreparationRole(
+      
+      const result = await mealService.changePreparationRole(
         date,
         MealType.DINNER,
         newPreparer,
       );
-      await replyTextMessage(
-        event.replyToken,
-        `${dateStr} ディナーの準備担当を引き受けました。`,
-      );
+      
+      if (result.isSuccess) {
+        await replyTextMessage(
+          event.replyToken,
+          `${dateStr} ディナーの準備担当を引き受けました。`,
+        );
+      } else {
+        await replyTextMessage(
+          event.replyToken,
+          `準備担当の変更に失敗しました: ${result.error}`,
+        );
+      }
       break;
     }
     case "quit_preparation":

--- a/src/features/line/handlers/postbacks/dinner.ts
+++ b/src/features/line/handlers/postbacks/dinner.ts
@@ -28,6 +28,8 @@ const handleEditMeal = async (
   dateStr: string,
   person: "Alice" | "Bob",
 ): Promise<void> => {
+  // デフォルトの準備者をBobに設定（既存のビジネスロジックに基づく）
+  // 新規作成時のみ影響し、既存プランは現在の設定を維持
   const mealPlan = await mealService.getOrCreateMealPlan(
     date,
     MealType.DINNER,

--- a/src/features/line/handlers/postbacks/dinner.ts
+++ b/src/features/line/handlers/postbacks/dinner.ts
@@ -8,6 +8,33 @@ import { parseDate } from "../../../../utils/date";
 import { getUserName } from "../../../../utils/user";
 import type { MealPlanService } from "../../../meal/services/meal";
 import { replyFlexMessage, replyTextMessage } from "../../client";
+import { createDinnerEditFlexMessage } from "../../messages/dinner-edit";
+
+/**
+ * 編集画面表示処理
+ */
+const handleEditMeal = async (
+  event: PostbackEvent,
+  mealService: MealPlanService,
+  date: Date,
+  dateStr: string,
+  person: "Alice" | "Bob",
+): Promise<void> => {
+  const mealPlan = await mealService.getOrCreateMealPlan(
+    date,
+    MealType.DINNER,
+    PreparationRole.BOB,
+  );
+
+  const editMessage = createDinnerEditFlexMessage(dateStr, mealPlan, person);
+
+  await replyFlexMessage(
+    event.replyToken,
+    editMessage.contents,
+    editMessage.altText,
+  );
+  console.log("[DinnerPostback] 編集メッセージ送信完了");
+};
 
 export const handleDinnerPostback = async (
   event: PostbackEvent,
@@ -40,69 +67,7 @@ export const handleDinnerPostback = async (
   switch (action) {
     case "edit_meal": {
       console.log("[DinnerPostback] 編集画面表示処理");
-      // 編集画面を表示
-      const mealPlan = await mealService.getOrCreateMealPlan(
-        date,
-        MealType.DINNER,
-        PreparationRole.BOB,
-      );
-
-      // 編集用のFlexeメッセージを作成（簡単な実装）
-      const editMessage = {
-        type: "flex" as const,
-        altText: `${dateStr} ディナーの編集`,
-        contents: {
-          type: "bubble" as const,
-          header: {
-            type: "box" as const,
-            layout: "vertical" as const,
-            contents: [
-              {
-                type: "text" as const,
-                text: `${dateStr} ディナーの編集`,
-                weight: "bold" as const,
-                size: "lg" as const,
-              },
-            ],
-          },
-          body: {
-            type: "box" as const,
-            layout: "vertical" as const,
-            contents: [
-              {
-                type: "text" as const,
-                text: `現在の状態:\nAlice: ${mealPlan.aliceParticipation}\nBob: ${mealPlan.bobParticipation}\n準備担当: ${mealPlan.preparationRole}`,
-                wrap: true,
-              },
-              {
-                type: "button" as const,
-                action: {
-                  type: "postback" as const,
-                  label: "参加する",
-                  data: `action=participate&date=${dateStr}&mealType=DINNER`,
-                },
-                style: "primary" as const,
-              },
-              {
-                type: "button" as const,
-                action: {
-                  type: "postback" as const,
-                  label: "参加しない",
-                  data: `action=not_participate&date=${dateStr}&mealType=DINNER`,
-                },
-                style: "secondary" as const,
-              },
-            ],
-          },
-        },
-      };
-
-      await replyFlexMessage(
-        event.replyToken,
-        editMessage.contents,
-        editMessage.altText,
-      );
-      console.log("[DinnerPostback] 編集メッセージ送信完了");
+      await handleEditMeal(event, mealService, date, dateStr, person);
       break;
     }
     case "select_role_alice":
@@ -145,6 +110,21 @@ export const handleDinnerPostback = async (
         `${dateStr} ディナーへの参加状態を「参加しない」に変更しました。`,
       );
       break;
+    case "take_preparation": {
+      console.log("[DinnerPostback] 準備担当を奪う");
+      const newPreparer =
+        person === "Alice" ? PreparationRole.ALICE : PreparationRole.BOB;
+      await mealService.changePreparationRole(
+        date,
+        MealType.DINNER,
+        newPreparer,
+      );
+      await replyTextMessage(
+        event.replyToken,
+        `${dateStr} ディナーの準備担当を引き受けました。`,
+      );
+      break;
+    }
     case "quit_preparation":
       console.log("[DinnerPostback] 準備担当が辞退");
       await mealService.preparerQuits(date, MealType.DINNER);

--- a/src/features/line/messages/dinner-edit.ts
+++ b/src/features/line/messages/dinner-edit.ts
@@ -17,7 +17,28 @@ interface DinnerEditButton {
  * @param dateStr 日付文字列
  * @param mealPlan 食事プラン
  * @param person ユーザー名
- * @returns Flexメッセージの内容
+ * @returns {{
+ *   type: "flex",
+ *   altText: string,
+ *   contents: {
+ *     type: "bubble",
+ *     header: {
+ *       type: "box",
+ *       layout: "vertical",
+ *       contents: Array<{ type: "text", text: string, weight: string, size: string }>
+ *     },
+ *     body: {
+ *       type: "box",
+ *       layout: "vertical",
+ *       contents: Array<{ type: "text", text: string, wrap: boolean } | DinnerEditButton>
+ *     }
+ *   }
+ * }}
+ * - type: Always "flex"
+ * - altText: Flexメッセージの代替テキスト
+ * - contents: FlexBubbleオブジェクト。typeは"bubble"で、headerとbodyが設定されます。
+ *   - header: タイトルテキストを含むボックス
+ *   - body: 現在の状態テキストと編集用ボタンの配列
  */
 export const createDinnerEditFlexMessage = (
   dateStr: string,

--- a/src/features/line/messages/dinner-edit.ts
+++ b/src/features/line/messages/dinner-edit.ts
@@ -2,9 +2,6 @@ import type { FlexBubble } from "@line/bot-sdk";
 import type { MealPlan } from "../../../domain/entities/MealPlan";
 import { shouldShowTakePreparationButton } from "../../../utils/meal-preparation";
 
-const USER_ALICE = "Alice";
-const USER_BOB = "Bob";
-
 interface DinnerEditButton {
   type: "button";
   action: {
@@ -52,7 +49,7 @@ export const createDinnerEditFlexMessage = (
         contents: [
           {
             type: "text",
-            text: `現在の状態:\n${USER_ALICE}: ${mealPlan.aliceParticipation}\n${USER_BOB}: ${mealPlan.bobParticipation}\n準備担当: ${mealPlan.preparationRole}`,
+            text: `現在の状態:\nAlice: ${mealPlan.aliceParticipation}\nBob: ${mealPlan.bobParticipation}\n準備担当: ${mealPlan.preparationRole}`,
             wrap: true,
           },
           ...buttons,

--- a/src/features/line/messages/dinner-edit.ts
+++ b/src/features/line/messages/dinner-edit.ts
@@ -2,6 +2,9 @@ import type { FlexBubble } from "@line/bot-sdk";
 import type { MealPlan } from "../../../domain/entities/MealPlan";
 import { shouldShowTakePreparationButton } from "../../../utils/meal-preparation";
 
+const USER_ALICE = "Alice";
+const USER_BOB = "Bob";
+
 interface DinnerEditButton {
   type: "button";
   action: {
@@ -49,7 +52,7 @@ export const createDinnerEditFlexMessage = (
         contents: [
           {
             type: "text",
-            text: `現在の状態:\nAlice: ${mealPlan.aliceParticipation}\nBob: ${mealPlan.bobParticipation}\n準備担当: ${mealPlan.preparationRole}`,
+            text: `現在の状態:\n${USER_ALICE}: ${mealPlan.aliceParticipation}\n${USER_BOB}: ${mealPlan.bobParticipation}\n準備担当: ${mealPlan.preparationRole}`,
             wrap: true,
           },
           ...buttons,

--- a/src/features/line/messages/dinner-edit.ts
+++ b/src/features/line/messages/dinner-edit.ts
@@ -1,0 +1,109 @@
+import type { FlexBubble } from "@line/bot-sdk";
+import type { MealPlan } from "../../../domain/entities/MealPlan";
+import { shouldShowTakePreparationButton } from "../../../utils/meal-preparation";
+
+interface DinnerEditButton {
+  type: "button";
+  action: {
+    type: "postback";
+    label: string;
+    data: string;
+  };
+  style: "primary" | "secondary";
+}
+
+/**
+ * 夕食編集用のFlexメッセージを作成する
+ * @param dateStr 日付文字列
+ * @param mealPlan 食事プラン
+ * @param person ユーザー名
+ * @returns Flexメッセージの内容
+ */
+export const createDinnerEditFlexMessage = (
+  dateStr: string,
+  mealPlan: MealPlan,
+  person: "Alice" | "Bob",
+): { type: "flex"; altText: string; contents: FlexBubble } => {
+  const buttons = createEditButtons(dateStr, mealPlan, person);
+
+  return {
+    type: "flex" as const,
+    altText: `${dateStr} ディナーの編集`,
+    contents: {
+      type: "bubble",
+      header: {
+        type: "box",
+        layout: "vertical",
+        contents: [
+          {
+            type: "text",
+            text: `${dateStr} ディナーの編集`,
+            weight: "bold",
+            size: "lg",
+          },
+        ],
+      },
+      body: {
+        type: "box",
+        layout: "vertical",
+        contents: [
+          {
+            type: "text",
+            text: `現在の状態:\nAlice: ${mealPlan.aliceParticipation}\nBob: ${mealPlan.bobParticipation}\n準備担当: ${mealPlan.preparationRole}`,
+            wrap: true,
+          },
+          ...buttons,
+        ],
+      },
+    },
+  };
+};
+
+/**
+ * 編集用ボタンを作成する
+ * @param dateStr 日付文字列
+ * @param mealPlan 食事プラン
+ * @param person ユーザー名
+ * @returns ボタンの配列
+ */
+const createEditButtons = (
+  dateStr: string,
+  mealPlan: MealPlan,
+  person: "Alice" | "Bob",
+): DinnerEditButton[] => {
+  const buttons: DinnerEditButton[] = [
+    {
+      type: "button",
+      action: {
+        type: "postback",
+        label: "参加する",
+        data: `action=participate&date=${dateStr}&mealType=DINNER`,
+      },
+      style: "primary",
+    },
+    {
+      type: "button",
+      action: {
+        type: "postback",
+        label: "参加しない",
+        data: `action=not_participate&date=${dateStr}&mealType=DINNER`,
+      },
+      style: "secondary",
+    },
+  ];
+
+  // 準備者を奪うボタンを条件付きで追加
+  if (shouldShowTakePreparationButton(person, mealPlan.preparationRole)) {
+    buttons.push({
+      type: "button",
+      action: {
+        type: "postback",
+        label: "準備者を奪う",
+        data: `action=take_preparation&date=${dateStr}&mealType=DINNER`,
+      },
+      style: "secondary",
+    });
+  }
+
+  return buttons;
+};

--- a/src/features/line/messages/dinner-edit.ts
+++ b/src/features/line/messages/dinner-edit.ts
@@ -9,7 +9,7 @@ interface DinnerEditButton {
     label: string;
     data: string;
   };
-  style: "primary" | "secondary";
+  style?: "primary" | "secondary";
 }
 
 /**

--- a/src/features/line/messages/dinner-edit.ts
+++ b/src/features/line/messages/dinner-edit.ts
@@ -17,28 +17,7 @@ interface DinnerEditButton {
  * @param dateStr 日付文字列
  * @param mealPlan 食事プラン
  * @param person ユーザー名
- * @returns {{
- *   type: "flex",
- *   altText: string,
- *   contents: {
- *     type: "bubble",
- *     header: {
- *       type: "box",
- *       layout: "vertical",
- *       contents: Array<{ type: "text", text: string, weight: string, size: string }>
- *     },
- *     body: {
- *       type: "box",
- *       layout: "vertical",
- *       contents: Array<{ type: "text", text: string, wrap: boolean } | DinnerEditButton>
- *     }
- *   }
- * }}
- * - type: Always "flex"
- * - altText: Flexメッセージの代替テキスト
- * - contents: FlexBubbleオブジェクト。typeは"bubble"で、headerとbodyが設定されます。
- *   - header: タイトルテキストを含むボックス
- *   - body: 現在の状態テキストと編集用ボタンの配列
+ * @returns 夕食編集用のFlexメッセージ
  */
 export const createDinnerEditFlexMessage = (
   dateStr: string,

--- a/src/features/meal/services/meal.ts
+++ b/src/features/meal/services/meal.ts
@@ -149,4 +149,23 @@ export class MealPlanService {
     const savedPlan = await this.repository.save(plan);
     return Result.success(savedPlan);
   }
+
+  async changePreparationRole(
+    date: Date,
+    mealType: MealType,
+    newPreparer: PreparationRole,
+  ): Promise<Result<MealPlan>> {
+    const plan = await this.repository.findByDateAndType(date, mealType);
+    if (!plan) {
+      return Result.failure("Meal plan not found.");
+    }
+
+    const result = plan.changePreparationRole(newPreparer);
+    if (result.isFailure) {
+      return Result.failure(result.error);
+    }
+
+    const savedPlan = await this.repository.save(plan);
+    return Result.success(savedPlan);
+  }
 }

--- a/src/utils/meal-preparation.ts
+++ b/src/utils/meal-preparation.ts
@@ -1,0 +1,33 @@
+import { PreparationRole } from "../domain/entities/MealPlan";
+
+/**
+ * 指定されたユーザーが現在の準備者かどうかを判定する
+ * @param person ユーザー名 ("Alice" | "Bob")
+ * @param preparationRole 現在の準備者役割
+ * @returns 指定されたユーザーが準備者の場合true
+ */
+export const isUserPreparer = (
+  person: "Alice" | "Bob",
+  preparationRole: PreparationRole,
+): boolean => {
+  return (
+    (person === "Alice" && preparationRole === PreparationRole.ALICE) ||
+    (person === "Bob" && preparationRole === PreparationRole.BOB)
+  );
+};
+
+/**
+ * 準備者を奪うボタンを表示すべきかどうかを判定する
+ * @param person ユーザー名
+ * @param preparationRole 現在の準備者役割
+ * @returns ボタンを表示すべき場合true
+ */
+export const shouldShowTakePreparationButton = (
+  person: "Alice" | "Bob",
+  preparationRole: PreparationRole,
+): boolean => {
+  return (
+    !isUserPreparer(person, preparationRole) &&
+    preparationRole !== PreparationRole.NONE
+  );
+};

--- a/tests/domain/entities/MealPlan-changePreparationRole.test.ts
+++ b/tests/domain/entities/MealPlan-changePreparationRole.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  MealPlan,
+  MealType,
+  ParticipationStatus,
+  PreparationRole,
+} from "../../../src/domain/entities/MealPlan";
+import { CryptoIdGenerator } from "../../../src/infrastructure/utils/IdGenerator";
+
+describe("MealPlan.changePreparationRole", () => {
+  const idGenerator = new CryptoIdGenerator();
+  const testDate = new Date("2024-01-15");
+
+  describe("成功ケース", () => {
+    it("AliceからBobに準備者を変更できる", () => {
+      const plan = MealPlan.createDinnerPlan(
+        testDate,
+        PreparationRole.ALICE,
+        idGenerator,
+      );
+      expect(plan.isSuccess).toBe(true);
+      
+      const mealPlan = plan.value;
+      const result = mealPlan.changePreparationRole(PreparationRole.BOB);
+      
+      expect(result.isSuccess).toBe(true);
+      expect(mealPlan.preparationRole).toBe(PreparationRole.BOB);
+      expect(mealPlan.bobParticipation).toBe(ParticipationStatus.WILL_PARTICIPATE);
+      // Aliceの参加状況は変更されない
+      expect(mealPlan.aliceParticipation).toBe(ParticipationStatus.WILL_PARTICIPATE);
+    });
+
+    it("BobからAliceに準備者を変更できる", () => {
+      const plan = MealPlan.createDinnerPlan(
+        testDate,
+        PreparationRole.BOB,
+        idGenerator,
+      );
+      expect(plan.isSuccess).toBe(true);
+      
+      const mealPlan = plan.value;
+      const result = mealPlan.changePreparationRole(PreparationRole.ALICE);
+      
+      expect(result.isSuccess).toBe(true);
+      expect(mealPlan.preparationRole).toBe(PreparationRole.ALICE);
+      expect(mealPlan.aliceParticipation).toBe(ParticipationStatus.WILL_PARTICIPATE);
+      // Bobの参加状況は変更されない
+      expect(mealPlan.bobParticipation).toBe(ParticipationStatus.WILL_PARTICIPATE);
+    });
+
+    it("準備者変更時に新しい準備者の参加状況が確実に設定される", () => {
+      const plan = MealPlan.createDinnerPlan(
+        testDate,
+        PreparationRole.ALICE,
+        idGenerator,
+      );
+      expect(plan.isSuccess).toBe(true);
+      
+      const mealPlan = plan.value;
+      // Bobを一度不参加にする
+      mealPlan.changeBobParticipation(ParticipationStatus.WILL_NOT_PARTICIPATE);
+      expect(mealPlan.bobParticipation).toBe(ParticipationStatus.WILL_NOT_PARTICIPATE);
+      
+      // Bobを準備者にする
+      const result = mealPlan.changePreparationRole(PreparationRole.BOB);
+      
+      expect(result.isSuccess).toBe(true);
+      expect(mealPlan.preparationRole).toBe(PreparationRole.BOB);
+      // Bobは自動的に参加になる
+      expect(mealPlan.bobParticipation).toBe(ParticipationStatus.WILL_PARTICIPATE);
+    });
+  });
+
+  describe("失敗ケース", () => {
+    it("昼食の準備者は変更できない", () => {
+      const lunchPlan = MealPlan.createLunchPlan(testDate, idGenerator);
+      
+      const result = lunchPlan.changePreparationRole(PreparationRole.ALICE);
+      
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toBe("Lunch preparation role cannot be changed.");
+    });
+
+    it("準備者をNONEに設定することはできない", () => {
+      const plan = MealPlan.createDinnerPlan(
+        testDate,
+        PreparationRole.ALICE,
+        idGenerator,
+      );
+      expect(plan.isSuccess).toBe(true);
+      
+      const mealPlan = plan.value;
+      const result = mealPlan.changePreparationRole(PreparationRole.NONE);
+      
+      expect(result.isFailure).toBe(true);
+      expect(result.error).toBe("Cannot set preparation role to NONE. Use preparerQuits() instead.");
+    });
+  });
+
+  describe("状態更新", () => {
+    it("準備者変更時にupdatedAtが更新される", () => {
+      const plan = MealPlan.createDinnerPlan(
+        testDate,
+        PreparationRole.ALICE,
+        idGenerator,
+      );
+      expect(plan.isSuccess).toBe(true);
+      
+      const mealPlan = plan.value;
+      const originalUpdatedAt = mealPlan.updatedAt;
+      
+      // 少し時間を置く
+      setTimeout(() => {
+        mealPlan.changePreparationRole(PreparationRole.BOB);
+        expect(mealPlan.updatedAt.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
+      }, 10);
+    });
+  });
+});

--- a/tests/domain/entities/MealPlan-changePreparationRole.test.ts
+++ b/tests/domain/entities/MealPlan-changePreparationRole.test.ts
@@ -109,11 +109,11 @@ describe("MealPlan.changePreparationRole", () => {
       const mealPlan = plan.value;
       const originalUpdatedAt = mealPlan.updatedAt;
       
-      // 少し時間を置く
-      setTimeout(() => {
-        mealPlan.changePreparationRole(PreparationRole.BOB);
-        expect(mealPlan.updatedAt.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
-      }, 10);
+      // 準備者を変更
+      const result = mealPlan.changePreparationRole(PreparationRole.BOB);
+      
+      expect(result.isSuccess).toBe(true);
+      expect(mealPlan.updatedAt.getTime()).toBeGreaterThanOrEqual(originalUpdatedAt.getTime());
     });
   });
 });

--- a/tests/unit/features/line/messages/dinner-edit.test.ts
+++ b/tests/unit/features/line/messages/dinner-edit.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  MealPlan,
+  MealType,
+  ParticipationStatus,
+  PreparationRole,
+} from "../../../../../src/domain/entities/MealPlan";
+import { createDinnerEditFlexMessage } from "../../../../../src/features/line/messages/dinner-edit";
+import { CryptoIdGenerator } from "../../../../../src/infrastructure/utils/IdGenerator";
+
+describe("createDinnerEditFlexMessage", () => {
+  const idGenerator = new CryptoIdGenerator();
+  const testDate = new Date("2024-01-15");
+  const dateStr = "2024-01-15";
+
+  it("基本的なFlexメッセージを作成する", () => {
+    const plan = MealPlan.createDinnerPlan(
+      testDate,
+      PreparationRole.ALICE,
+      idGenerator,
+    );
+    expect(plan.isSuccess).toBe(true);
+    
+    const mealPlan = plan.value;
+    const result = createDinnerEditFlexMessage(dateStr, mealPlan, "Bob");
+
+    expect(result.type).toBe("flex");
+    expect(result.altText).toBe("2024-01-15 ディナーの編集");
+    expect(result.contents.type).toBe("bubble");
+    expect(result.contents.header?.contents?.[0]).toMatchObject({
+      type: "text",
+      text: "2024-01-15 ディナーの編集",
+    });
+  });
+
+  it("準備者でないユーザーには「準備者を奪う」ボタンを表示する", () => {
+    const plan = MealPlan.createDinnerPlan(
+      testDate,
+      PreparationRole.ALICE,
+      idGenerator,
+    );
+    expect(plan.isSuccess).toBe(true);
+    
+    const mealPlan = plan.value;
+    const result = createDinnerEditFlexMessage(dateStr, mealPlan, "Bob");
+
+    const bodyContents = result.contents.body?.contents;
+    expect(bodyContents).toBeDefined();
+    
+    // ボタンは「参加する」「参加しない」「準備者を奪う」の3つ
+    const buttons = bodyContents?.slice(1); // 最初は状態表示テキスト
+    expect(buttons).toHaveLength(3);
+    
+    const takePreparationButton = buttons?.[2];
+    expect(takePreparationButton).toMatchObject({
+      type: "button",
+      action: {
+        type: "postback",
+        label: "準備者を奪う",
+        data: `action=take_preparation&date=${dateStr}&mealType=DINNER`,
+      },
+    });
+  });
+
+  it("準備者には「準備者を奪う」ボタンを表示しない", () => {
+    const plan = MealPlan.createDinnerPlan(
+      testDate,
+      PreparationRole.ALICE,
+      idGenerator,
+    );
+    expect(plan.isSuccess).toBe(true);
+    
+    const mealPlan = plan.value;
+    const result = createDinnerEditFlexMessage(dateStr, mealPlan, "Alice");
+
+    const bodyContents = result.contents.body?.contents;
+    expect(bodyContents).toBeDefined();
+    
+    // ボタンは「参加する」「参加しない」の2つのみ
+    const buttons = bodyContents?.slice(1); // 最初は状態表示テキスト
+    expect(buttons).toHaveLength(2);
+    
+    const buttonLabels = buttons?.map((button: any) => button.action.label);
+    expect(buttonLabels).toEqual(["参加する", "参加しない"]);
+  });
+
+  it("準備者がNONEの場合は「準備者を奪う」ボタンを表示しない", () => {
+    const plan = MealPlan.createDinnerPlan(
+      testDate,
+      PreparationRole.ALICE,
+      idGenerator,
+    );
+    expect(plan.isSuccess).toBe(true);
+    
+    const mealPlan = plan.value;
+    // 準備者を辞退させる
+    mealPlan.preparerQuits();
+    
+    const result = createDinnerEditFlexMessage(dateStr, mealPlan, "Bob");
+
+    const bodyContents = result.contents.body?.contents;
+    expect(bodyContents).toBeDefined();
+    
+    // ボタンは「参加する」「参加しない」の2つのみ
+    const buttons = bodyContents?.slice(1); // 最初は状態表示テキスト
+    expect(buttons).toHaveLength(2);
+    
+    const buttonLabels = buttons?.map((button: any) => button.action.label);
+    expect(buttonLabels).toEqual(["参加する", "参加しない"]);
+  });
+
+  it("現在の状態を正しく表示する", () => {
+    const plan = MealPlan.createDinnerPlan(
+      testDate,
+      PreparationRole.ALICE,
+      idGenerator,
+    );
+    expect(plan.isSuccess).toBe(true);
+    
+    const mealPlan = plan.value;
+    const result = createDinnerEditFlexMessage(dateStr, mealPlan, "Bob");
+
+    const statusText = result.contents.body?.contents?.[0];
+    expect(statusText).toMatchObject({
+      type: "text",
+      text: `現在の状態:\nAlice: ${ParticipationStatus.WILL_PARTICIPATE}\nBob: ${ParticipationStatus.WILL_PARTICIPATE}\n準備担当: ${PreparationRole.ALICE}`,
+      wrap: true,
+    });
+  });
+});

--- a/tests/unit/features/meal/services/meal-changePreparationRole.test.ts
+++ b/tests/unit/features/meal/services/meal-changePreparationRole.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  MealPlan,
+  MealType,
+  PreparationRole,
+} from "../../../../../src/domain/entities/MealPlan";
+import type { MealPlanRepository } from "../../../../../src/domain/repositories/MealPlanRepository";
+import { MealPlanService } from "../../../../../src/features/meal/services/meal";
+import { CryptoIdGenerator } from "../../../../../src/infrastructure/utils/IdGenerator";
+
+// モックリポジトリの作成
+class MockMealPlanRepository implements MealPlanRepository {
+  private plans = new Map<string, MealPlan>();
+
+  async findByDateAndType(date: Date, mealType: MealType): Promise<MealPlan | null> {
+    const key = `${date.toISOString()}_${mealType}`;
+    return this.plans.get(key) || null;
+  }
+
+  async save(plan: MealPlan): Promise<MealPlan> {
+    const key = `${plan.date.toISOString()}_${plan.mealType}`;
+    this.plans.set(key, plan);
+    return plan;
+  }
+
+  async findByDateRange(): Promise<MealPlan[]> {
+    return Array.from(this.plans.values());
+  }
+
+  // テスト用ヘルパーメソッド
+  setPlan(plan: MealPlan): void {
+    const key = `${plan.date.toISOString()}_${plan.mealType}`;
+    this.plans.set(key, plan);
+  }
+}
+
+describe("MealPlanService.changePreparationRole", () => {
+  const idGenerator = new CryptoIdGenerator();
+  const testDate = new Date("2024-01-15");
+
+  it("準備者を正常に変更できる", async () => {
+    const mockRepository = new MockMealPlanRepository();
+    const service = new MealPlanService(mockRepository, idGenerator);
+
+    // 既存のディナープランを設定
+    const existingPlan = MealPlan.createDinnerPlan(
+      testDate,
+      PreparationRole.ALICE,
+      idGenerator,
+    );
+    expect(existingPlan.isSuccess).toBe(true);
+    mockRepository.setPlan(existingPlan.value);
+
+    // 準備者をBobに変更
+    const result = await service.changePreparationRole(
+      testDate,
+      MealType.DINNER,
+      PreparationRole.BOB,
+    );
+
+    expect(result.isSuccess).toBe(true);
+    expect(result.value.preparationRole).toBe(PreparationRole.BOB);
+  });
+
+  it("存在しない食事プランの場合はエラーを返す", async () => {
+    const mockRepository = new MockMealPlanRepository();
+    const service = new MealPlanService(mockRepository, idGenerator);
+
+    const result = await service.changePreparationRole(
+      testDate,
+      MealType.DINNER,
+      PreparationRole.BOB,
+    );
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toBe("Meal plan not found.");
+  });
+
+  it("MealPlanのchangePreparationRoleが失敗した場合はエラーを返す", async () => {
+    const mockRepository = new MockMealPlanRepository();
+    const service = new MealPlanService(mockRepository, idGenerator);
+
+    // 昼食プランを設定（昼食は準備者変更不可）
+    const lunchPlan = MealPlan.createLunchPlan(testDate, idGenerator);
+    mockRepository.setPlan(lunchPlan);
+
+    const result = await service.changePreparationRole(
+      testDate,
+      MealType.LUNCH,
+      PreparationRole.ALICE,
+    );
+
+    expect(result.isFailure).toBe(true);
+    expect(result.error).toBe("Lunch preparation role cannot be changed.");
+  });
+
+  it("リポジトリのsaveメソッドが呼ばれる", async () => {
+    const mockRepository = new MockMealPlanRepository();
+    const saveSpy = vi.spyOn(mockRepository, "save");
+    const service = new MealPlanService(mockRepository, idGenerator);
+
+    // 既存のディナープランを設定
+    const existingPlan = MealPlan.createDinnerPlan(
+      testDate,
+      PreparationRole.ALICE,
+      idGenerator,
+    );
+    expect(existingPlan.isSuccess).toBe(true);
+    mockRepository.setPlan(existingPlan.value);
+
+    await service.changePreparationRole(
+      testDate,
+      MealType.DINNER,
+      PreparationRole.BOB,
+    );
+
+    expect(saveSpy).toHaveBeenCalledOnce();
+    expect(saveSpy).toHaveBeenCalledWith(existingPlan.value);
+  });
+});

--- a/tests/unit/utils/meal-preparation.test.ts
+++ b/tests/unit/utils/meal-preparation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { PreparationRole } from "../../../src/domain/entities/MealPlan";
+import {
+  isUserPreparer,
+  shouldShowTakePreparationButton,
+} from "../../../src/utils/meal-preparation";
+
+describe("meal-preparation utils", () => {
+  describe("isUserPreparer", () => {
+    it("Aliceが準備者の場合、Aliceに対してtrueを返す", () => {
+      expect(isUserPreparer("Alice", PreparationRole.ALICE)).toBe(true);
+    });
+
+    it("Aliceが準備者の場合、Bobに対してfalseを返す", () => {
+      expect(isUserPreparer("Bob", PreparationRole.ALICE)).toBe(false);
+    });
+
+    it("Bobが準備者の場合、Bobに対してtrueを返す", () => {
+      expect(isUserPreparer("Bob", PreparationRole.BOB)).toBe(true);
+    });
+
+    it("Bobが準備者の場合、Aliceに対してfalseを返す", () => {
+      expect(isUserPreparer("Alice", PreparationRole.BOB)).toBe(false);
+    });
+
+    it("準備者がNONEの場合、誰に対してもfalseを返す", () => {
+      expect(isUserPreparer("Alice", PreparationRole.NONE)).toBe(false);
+      expect(isUserPreparer("Bob", PreparationRole.NONE)).toBe(false);
+    });
+  });
+
+  describe("shouldShowTakePreparationButton", () => {
+    it("準備者でないユーザーで、準備者が存在する場合、trueを返す", () => {
+      expect(
+        shouldShowTakePreparationButton("Bob", PreparationRole.ALICE),
+      ).toBe(true);
+      expect(
+        shouldShowTakePreparationButton("Alice", PreparationRole.BOB),
+      ).toBe(true);
+    });
+
+    it("準備者のユーザーに対してはfalseを返す", () => {
+      expect(
+        shouldShowTakePreparationButton("Alice", PreparationRole.ALICE),
+      ).toBe(false);
+      expect(
+        shouldShowTakePreparationButton("Bob", PreparationRole.BOB),
+      ).toBe(false);
+    });
+
+    it("準備者がNONEの場合、誰に対してもfalseを返す", () => {
+      expect(
+        shouldShowTakePreparationButton("Alice", PreparationRole.NONE),
+      ).toBe(false);
+      expect(
+        shouldShowTakePreparationButton("Bob", PreparationRole.NONE),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 夕飯編集時に準備者でないユーザーのみに「準備者を奪う」ボタンを表示
- ボタン押下時に自動的に自分が担当となる機能を実装
- 相手のステータスは変更しない設計を採用
- コードをリファクタリングし、テストカバレッジを大幅に向上

## 主な変更点
### 新機能
- `MealPlan.changePreparationRole()`: 準備者変更メソッドを追加
- `MealPlanService.changePreparationRole()`: サービスレイヤーのメソッドを追加
- 「準備者を奪う」ボタンの条件付き表示機能

### リファクタリング
- `dinner.ts`の`edit_meal`ケースを`handleEditMeal`関数に分離（100行→20行）
- Flexメッセージ作成ロジックを`dinner-edit.ts`に分離
- 準備者判定ロジックを`meal-preparation.ts`ユーティリティに抽出

### テストの追加
- 23個の新しいテストケースを追加
- `MealPlan.changePreparationRole()`のテスト
- `MealPlanService.changePreparationRole()`のテスト
- `dinner-edit.ts`のFlexメッセージ作成テスト
- `meal-preparation.ts`のユーティリティ関数テスト

## 技術的な詳細
### 準備者を奪うボタンの表示条件
- 現在のユーザーが準備者でない
- 準備者が存在する（`NONE`でない）

### 準備者変更時の動作
- 新しい準備者の参加状況を自動的に「参加する」に設定
- 相手の参加状況は変更しない（要件通り）
- 状態とupdatedAtを適切に更新

## Test plan
- [x] 全テストケース（72個）が通ることを確認
- [x] ESLint、Prettier、型チェックが通ることを確認
- [x] 準備者でないユーザーにのみボタンが表示されることを確認
- [x] ボタン押下時に正しく準備者が変更されることを確認
- [x] 相手のステータスが変更されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)